### PR TITLE
Recognize comments in mutli-line argument lists

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -19,7 +19,7 @@ endif
 " match class/definition/node declarations
 syn region  puppetDefine        start="^\s*\(class\|define\|node\)\s" end="{" contains=puppetDefType,puppetDefName,puppetDefArguments,puppetNodeRe
 syn keyword puppetDefType       class define node inherits contained
-syn region  puppetDefArguments  start="(" end=")" contained contains=puppetArgument,puppetString
+syn region  puppetDefArguments  start="(" end=")" contained contains=puppetArgument,puppetString,puppetComment
 syn match   puppetArgument      "\w\+" contained
 syn match   puppetArgument      "\$\w\+" contained
 syn match   puppetArgument      "'[^']+'" contained


### PR DESCRIPTION
Vim doesn't currently highlight my comments, but puppet appears to recognize them (and I would sure hope it would).

Thanks!
