### PR TITLE
Fix syntax highlighting of class definition arguments

### DIFF
--- a/syntax/puppet.vim
+++ b/syntax/puppet.vim
@@ -19,7 +19,8 @@ endif
 " match class/definition/node declarations
 syn region  puppetDefine        start="^\s*\(class\|define\|node\)\s" end="{" contains=puppetDefType,puppetDefName,puppetDefArguments,puppetNodeRe
 syn keyword puppetDefType       class define node inherits contained
-syn region  puppetDefArguments  start="(" end=")" contained contains=puppetArgument,puppetString
+syn region  puppetDefArguments  start="(" end=")" contained contains=puppetDefValues,puppetArgument,puppetDefName,puppetComment,puppetMultilineComment
+syn region  puppetDefValues     start="(" end=")" contained contains=puppetArgument,puppetString,puppetDefName,puppetSpecial
 syn match   puppetArgument      "\w\+" contained
 syn match   puppetArgument      "\$\w\+" contained
 syn match   puppetArgument      "'[^']+'" contained


### PR DESCRIPTION
The `puppetDefArguments` region incorrectly highlights arguments if they contain functions due to braces in those functions that make the region to end at the first such argument, not at the end of definitions. See the example below:
```
class profile::dao::aio (
  $yum_baseurl            = hiera('yum::baseurl'),
  $yum_baseurl_deps       = hiera('yum::baseurl_deps'),

  # Comment here
  $debug                  = hiera('debug', false),
) { ... }
```

Suggested changes handle situations with functions in class definition better and also highlight inline comments.

Please review and feel free to express any concerns, I'll do further improvement to address those.