### PR TITLE
Update puppet.vim

### DIFF
--- a/ftplugin/puppet.vim
+++ b/ftplugin/puppet.vim
@@ -4,6 +4,9 @@
 " Last Change:  2009 Aug 19
 " vim: set sw=4 sts=4:
 
+setlocal shiftwidth=2
+setlocal tabstop=2
+
 if exists("b:did_ftplugin")
     finish
 endif


### PR DESCRIPTION
The best practices for puppet indentation files is 2 spaces.

source : https://docs.puppetlabs.com/guides/style_guide.html#spacing-indentation-and-whitespace